### PR TITLE
APX-8084: upgrade jetty to 10.0.24 to address snyk vuln CVE-2024-8184

### DIFF
--- a/roth-lib-java-service/pom.xml
+++ b/roth-lib-java-service/pom.xml
@@ -17,7 +17,7 @@
 		<dependency>
 		    <groupId>org.eclipse.jetty</groupId>
 		    <artifactId>jetty-server</artifactId>
-		    <version>10.0.20</version>
+		    <version>10.0.24</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.eclipse.jetty</groupId>
@@ -29,19 +29,19 @@
 		<dependency>
 		    <groupId>org.eclipse.jetty</groupId>
 		    <artifactId>jetty-http</artifactId>
-		    <version>10.0.20</version>
+		    <version>10.0.24</version>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-servlet -->
 		<dependency>
 		    <groupId>org.eclipse.jetty</groupId>
 		    <artifactId>jetty-servlet</artifactId>
-		    <version>10.0.20</version>
+		    <version>10.0.24</version>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-webapp -->
 		<dependency>
 		    <groupId>org.eclipse.jetty</groupId>
 		    <artifactId>jetty-webapp</artifactId>
-		    <version>10.0.20</version>
+		    <version>10.0.24</version>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/com.google.guava/guava -->
 		<dependency>


### PR DESCRIPTION
[APX-8084](https://inhabitiq.atlassian.net/browse/APX-8084)

Upgrading jetty to version 10.0.24 addressing snyk [SNYK-JAVA-ORGECLIPSEJETTY-8186142](https://app.snyk.io/org/apx-aptexx/project/c2a9d5b7-a5c3-427b-b1bf-f1df2263025e#issue-SNYK-JAVA-ORGECLIPSEJETTY-8186142)

[APX-8084]: https://inhabitiq.atlassian.net/browse/APX-8084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ